### PR TITLE
Use flex layout for story container

### DIFF
--- a/nebula-art/index.html
+++ b/nebula-art/index.html
@@ -16,7 +16,7 @@
   <style>
     html,body{margin:0;height:100%;background:black;overflow:hidden}
     canvas{display:block}
-    #story-container{position:absolute;top:0;left:0;width:100%;height:100%;display:none;z-index:10;color:white;background:rgba(0,0,0,0.6);padding:20px;box-sizing:border-box}
+    #story-container{position:absolute;top:0;left:0;width:100%;height:100%;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;display:none;z-index:10;color:white;background:rgba(0,0,0,0.6);padding:20px;box-sizing:border-box}
     #story-container>*{margin-bottom:1em}
   </style>
 </head>

--- a/nebula-art/sketch.js
+++ b/nebula-art/sketch.js
@@ -59,7 +59,7 @@ let whispersEnabled = true;
 function handleMode() {
   const isWhispers = params.mode === 'Whispers';
   const el = document.getElementById('story-container');
-  if (el) el.style.display = isWhispers ? 'none' : 'block';
+  if (el) el.style.display = isWhispers ? 'none' : 'flex';
   whispersEnabled = isWhispers;
 }
 // Built-in palettes (HSB triples)


### PR DESCRIPTION
## Summary
- Update story container CSS to use flexbox alignment while remaining hidden by default
- Toggle story container display between none and flex when switching modes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8e731e6c8320995876c00d37672f