### PR TITLE
Propagate whisper text defaults to story overlay

### DIFF
--- a/nebula-art/sketch.js
+++ b/nebula-art/sketch.js
@@ -1,4 +1,4 @@
-import { createWhispers } from './whispers.js';
+import { createWhispers, TEXT_DEFAULTS } from './whispers.js';
 
 // =====================
 // Vignette settings
@@ -136,7 +136,7 @@ function setup() {
 
   // Whispers overlay module
   whispers = createWhispers(gui, () => params.palette);
-  storyEngine = NebulaStory.quickBind({});
+  storyEngine = NebulaStory.quickBind({ textDefaults: TEXT_DEFAULTS });
   handleMode();
 
   // Hide GUI by default unless ?gui=1

--- a/nebula-art/story.js
+++ b/nebula-art/story.js
@@ -215,7 +215,8 @@
       choicesId = "story-choices",
       endingIdEl = "story-ending",
       pathId = "story-path",
-      onChoiceSound // optional function(key) to play SFX
+      onChoiceSound, // optional function(key) to play SFX
+      textDefaults  // optional styling overrides
     } = cfg || {};
 
     const $title = document.getElementById(titleId);
@@ -223,6 +224,33 @@
     const $choices = document.getElementById(choicesId);
     const $ending = document.getElementById(endingIdEl);
     const $path = document.getElementById(pathId);
+    const $container = $title ? $title.parentElement : null;
+
+    // apply text defaults if provided
+    if (textDefaults) {
+      const { textFont, textSize, textColor, textStyle, textShadow, textBoxWidth } = textDefaults;
+      const targets = [$title, $body, $choices, $ending, $path];
+      targets.forEach(el => {
+        if (!el) return;
+        if (textFont) el.style.fontFamily = textFont;
+        if (textSize) el.style.fontSize = textSize + 'px';
+        if (textColor) el.style.color = textColor;
+        if (textStyle === 'Italic') {
+          el.style.fontStyle = 'italic';
+          el.style.fontWeight = 'normal';
+        } else if (textStyle === 'Bold') {
+          el.style.fontWeight = 'bold';
+          el.style.fontStyle = 'normal';
+        } else {
+          el.style.fontStyle = 'normal';
+          el.style.fontWeight = 'normal';
+        }
+        el.style.textShadow = textShadow ? '2px 2px 4px rgba(0,0,0,0.6)' : 'none';
+      });
+      if ($container && textBoxWidth) {
+        $container.style.maxWidth = (textBoxWidth * 100) + '%';
+      }
+    }
 
     const engine = createStoryEngine({
       onRenderNode: (node, step, path) => {

--- a/nebula-art/whispers.js
+++ b/nebula-art/whispers.js
@@ -1,20 +1,24 @@
 // whispers.js - overlay text with fades + personalization + font + positioning
+
+// exported defaults so other modules can match styling
+export const TEXT_DEFAULTS = {
+  textEnabled:  true,
+  textSize:     72,
+  textColor:    '#ff9292',
+  textShadow:   true,
+  textFadeInMs: 2000,
+  textHoldMs:   4500,
+  textFadeOutMs:2000,
+  useGeolocation: false,
+  textPosition: 'Center',           // 'Center' | 'Bottom' | 'Top'
+  textFont:     'Kaushan Script',   // must exist via CSS or system
+  textStyle:    'Normal',           // 'Normal' | 'Italic' | 'Bold'
+  textBoxWidth: 0.8                 // fraction of canvas width
+};
+
 export function createWhispers(gui, getPaletteName) {
   // params local to this module
-  const params = {
-    textEnabled:  true,
-    textSize:     72,
-    textColor:    '#ff9292',
-    textShadow:   true,
-    textFadeInMs: 2000,
-    textHoldMs:   4500,
-    textFadeOutMs:2000,
-    useGeolocation: false,
-    textPosition: 'Center',           // 'Center' | 'Bottom' | 'Top'
-    textFont:     'Kaushan Script',   // must exist via CSS or system
-    textStyle:    'Normal',           // 'Normal' | 'Italic' | 'Bold'
-    textBoxWidth: 0.8                 // fraction of canvas width
-  };
+  const params = { ...TEXT_DEFAULTS };
 
   // default templates with tokens - added new lines
   const DEFAULT_TEMPLATES = [


### PR DESCRIPTION
## Summary
- export whisper text parameters as `TEXT_DEFAULTS`
- allow `NebulaStory.quickBind` to apply text defaults to DOM elements
- initialize story overlay with whisper styling

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8e710b848320b5f185d831143d9d