### PR TITLE
Load sketch.js as module and remove redundant script

### DIFF
--- a/nebula-art/index.html
+++ b/nebula-art/index.html
@@ -38,8 +38,7 @@
 
   <!-- Scripts: p5 first, then your sketch, then engines, then wiring -->
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.min.js"></script>
-  <script src="sketch.js"></script>
-  <script src="whispers.js"></script>
+  <script type="module" src="sketch.js"></script>
   <script src="story.js"></script>
   <script src="main.js"></script>
 


### PR DESCRIPTION
## Summary
- Load `sketch.js` via an ES module script.
- Remove standalone `whispers.js` include since it's imported by `sketch.js`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e9d7a974c83209b0229cbc59daa30