### PR TITLE
Expose whispers toggle and sync mode switching

### DIFF
--- a/nebula-art/main.js
+++ b/nebula-art/main.js
@@ -10,11 +10,13 @@
   function startWhispers() {
     $storyUI.hidden = true;
     // sketch keeps running underneath
+    window.setWhispersEnabled(true);
   }
 
   function startStory() {
     $storyUI.hidden = false;
     // sketch keeps running underneath
+    window.setWhispersEnabled(false);
     if (!storyEngine) {
       storyEngine = window.NebulaStory.quickBind({
         titleId: "story-title",

--- a/nebula-art/sketch.js
+++ b/nebula-art/sketch.js
@@ -59,6 +59,7 @@ let guiHidden = false;
 let whispers;
 let storyEngine;
 let whispersEnabled = true;
+window.setWhispersEnabled = flag => { whispersEnabled = flag; };
 
 function handleMode() {
   const isWhispers = params.mode === 'Whispers';


### PR DESCRIPTION
## Summary
- expose `setWhispersEnabled` globally to control whisper overlay
- ensure mode changes call the helper so whisper text hides or shows appropriately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea0c0d71c8320979bf01b67552371