### PR TITLE
Set Story as default mode

### DIFF
--- a/nebula-art/index.html
+++ b/nebula-art/index.html
@@ -16,12 +16,12 @@
 
   <!-- Mode switch -->
   <div id="mode-switch" role="group" aria-label="Mode switch">
-    <button class="btn active" data-mode="whispers" type="button" aria-pressed="true">Whispers</button>
-    <button class="btn" data-mode="story" type="button" aria-pressed="false">Story</button>
+    <button class="btn" data-mode="whispers" type="button" aria-pressed="false">Whispers</button>
+    <button class="btn active" data-mode="story" type="button" aria-pressed="true">Story</button>
   </div>
 
   <!-- Story UI overlay: now centered, transparent, inherits Whisper font -->
-  <section id="story-ui" hidden>
+  <section id="story-ui">
     <div id="story-wrap">
       <h2 id="story-title"></h2>
       <p id="story-body"></p>

--- a/nebula-art/main.js
+++ b/nebula-art/main.js
@@ -51,11 +51,11 @@
   // Hotkey: T toggles modes
   window.addEventListener("keydown", (e) => {
     if (e.key.toLowerCase() === "t" && !e.altKey && !e.ctrlKey && !e.metaKey) {
-      const current = localStorage.getItem("nebula_mode") || "whispers";
+      const current = localStorage.getItem("nebula_mode") || "story";
       setMode(current === "whispers" ? "story" : "whispers");
     }
   });
 
-  const preferred = localStorage.getItem("nebula_mode") || "whispers";
+  const preferred = localStorage.getItem("nebula_mode") || "story";
   setMode(preferred);
 })();


### PR DESCRIPTION
## Summary
- Move active state to Story button and reveal story UI on load
- Default to Story mode when no mode preference is stored

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea430f5b48320b1dd1ec4df442b53