### PR TITLE
Ensure replay button starts on its own line after hint

### DIFF
--- a/nebula-art/story.js
+++ b/nebula-art/story.js
@@ -146,6 +146,10 @@
           hint.textContent = end.whisper;
           $choices.appendChild(hint);
 
+          // break line so replay button sits below hint
+          const br = document.createElement("br");
+          $choices.appendChild(br);
+
           const again = document.createElement("button");
           again.className = "btn again";
           again.textContent = "Try a different cadence";


### PR DESCRIPTION
## Summary
- Insert explicit line break after the ending hint so the replay button displays beneath it.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea55558248320ab7e7831394ee135