### PR TITLE
Decouple whisper and story modules with central coordinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# endub-22.github.io
+# Nebula Art
+
+This repository hosts the **Nebula Art** experiment. The web app is
+composed of several small scripts coordinated by `main.js`.
+
+## Module Overview
+
+| File | Purpose |
+| --- | --- |
+| `nebula-art/main.js` | Loads the p5 sketch and toggles between **Whispers** and **Story** modes. Modules are imported on demand. |
+| `nebula-art/sketch.js` | Renders the animated nebula background and exposes helpers for attaching overlays. Parameter controls are managed here via dat.GUI. |
+| `nebula-art/whispers.js` | Defines the text overlay shown in Whispers mode. Exports `createWhispers` and `TEXT_DEFAULTS`. |
+| `nebula-art/story.js` | Implements the "Whispers from the Nebula" choose‑your‑own‑adventure and exposes a global `NebulaStory` helper. |
+
+## Key Parameters
+
+`sketch.js` maintains a `params` object that controls the appearance of
+the nebula:
+
+- `noiseScale`, `tSpeed`, `octaves`, `falloff`, `downsample`
+- `palette` – name of the active colour palette
+- `vignette` settings – `strength`, `radius`, `softness`, `x`, and `y`
+
+`whispers.js` exposes `TEXT_DEFAULTS` describing the text overlay:
+
+- `textEnabled`, `textSize`, `textColor`, `textShadow`
+- `textFadeInMs`, `textHoldMs`, `textFadeOutMs`
+- `textFont`, `textStyle`, `textPosition`, `textBoxWidth`
+
+The selected mode is persisted in `localStorage` as `nebula_mode`.
+

--- a/nebula-art/index.html
+++ b/nebula-art/index.html
@@ -37,15 +37,10 @@
     </div>
   </noscript>
 
-  <!-- Scripts: p5 first, then your sketch, then engines, then wiring -->
+  <!-- Scripts: p5, dat.GUI, then main coordinator -->
   <script src="https://cdn.jsdelivr.net/npm/p5@1.9.3/lib/p5.min.js"></script>
-
   <script src="https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.min.js"></script>
- 
-  <!-- whispers.js is imported by sketch.js -->
-  <script type="module" src="sketch.js"></script>
-  <script src="story.js"></script>
-  <script src="main.js"></script>
+  <script type="module" src="main.js"></script>
 
   <!-- Ripple effect: adds a soft ink ripple to any .btn -->
   <script>

--- a/nebula-art/main.js
+++ b/nebula-art/main.js
@@ -1,61 +1,84 @@
-/* main.js - keep sketch running; center Story UI */
-(function () {
-  "use strict";
+/* main.js - coordinate sketch, whispers, and story */
+"use strict";
 
-  const $switch = document.getElementById("mode-switch");
-  const $storyUI = document.getElementById("story-ui");
+import {
+  setWhispersOverlay,
+  setWhispersEnabled,
+  getGUI,
+  getPaletteName
+} from "./sketch.js";
 
-  let storyEngine = null;
+const $switch = document.getElementById("mode-switch");
+const $storyUI = document.getElementById("story-ui");
 
-  function startWhispers() {
-    $storyUI.hidden = true;
-    // sketch keeps running underneath
-    window.setWhispersEnabled(true);
+let storyEngine = null;
+let whispersLoaded = false;
+
+function waitForGUI() {
+  return new Promise(resolve => {
+    const check = () => {
+      const g = getGUI();
+      if (g) resolve(g); else requestAnimationFrame(check);
+    };
+    check();
+  });
+}
+
+async function startWhispers() {
+  $storyUI.hidden = true;
+  setWhispersEnabled(true);
+  if (!whispersLoaded) {
+    const mod = await import("./whispers.js");
+    const gui = await waitForGUI();
+    const overlay = mod.createWhispers(gui, getPaletteName);
+    setWhispersOverlay(overlay);
+    whispersLoaded = true;
   }
+}
 
-  function startStory() {
-    $storyUI.hidden = false;
-    // sketch keeps running underneath
-    window.setWhispersEnabled(false);
-    if (!storyEngine) {
-      storyEngine = window.NebulaStory.quickBind({
-        titleId: "story-title",
-        bodyId: "story-body",
-        choicesId: "story-choices",
-        endingIdEl: "story-ending",
-        pathId: "story-path",
-        onChoiceSound: null
-      });
-    } else {
-      storyEngine.reset();
-    }
-  }
-
-  function setMode(mode) {
-    const btns = $switch.querySelectorAll("button[data-mode]");
-    btns.forEach(b => {
-      const active = b.dataset.mode === mode;
-      b.classList.toggle("active", active);
-      b.setAttribute("aria-pressed", String(active));
+async function startStory() {
+  $storyUI.hidden = false;
+  setWhispersEnabled(false);
+  if (!storyEngine) {
+    await import("./story.js");
+    storyEngine = window.NebulaStory.quickBind({
+      titleId: "story-title",
+      bodyId: "story-body",
+      choicesId: "story-choices",
+      endingIdEl: "story-ending",
+      pathId: "story-path",
+      onChoiceSound: null
     });
-    localStorage.setItem("nebula_mode", mode);
-    if (mode === "story") startStory(); else startWhispers();
+  } else {
+    storyEngine.reset();
   }
+}
 
-  $switch.addEventListener("click", (e) => {
-    const btn = e.target.closest("button[data-mode]");
-    if (!btn) return;
-    setMode(btn.dataset.mode);
+function setMode(mode) {
+  const btns = $switch.querySelectorAll("button[data-mode]");
+  btns.forEach(b => {
+    const active = b.dataset.mode === mode;
+    b.classList.toggle("active", active);
+    b.setAttribute("aria-pressed", String(active));
   });
+  localStorage.setItem("nebula_mode", mode);
+  if (mode === "story") startStory(); else startWhispers();
+}
 
-  // Hotkey: T toggles modes
-  window.addEventListener("keydown", (e) => {
-    if (e.key.toLowerCase() === "t" && !e.altKey && !e.ctrlKey && !e.metaKey) {
-      const current = localStorage.getItem("nebula_mode") || "story";
-      setMode(current === "whispers" ? "story" : "whispers");
-    }
-  });
+$switch.addEventListener("click", e => {
+  const btn = e.target.closest("button[data-mode]");
+  if (!btn) return;
+  setMode(btn.dataset.mode);
+});
 
-  const preferred = localStorage.getItem("nebula_mode") || "story";
-  setMode(preferred);
-})();
+// Hotkey: T toggles modes
+window.addEventListener("keydown", e => {
+  if (e.key.toLowerCase() === "t" && !e.altKey && !e.ctrlKey && !e.metaKey) {
+    const current = localStorage.getItem("nebula_mode") || "story";
+    setMode(current === "whispers" ? "story" : "whispers");
+  }
+});
+
+const preferred = localStorage.getItem("nebula_mode") || "story";
+setMode(preferred);
+

--- a/nebula-art/sketch.js
+++ b/nebula-art/sketch.js
@@ -1,4 +1,5 @@
-import { createWhispers, TEXT_DEFAULTS } from './whispers.js';
+// Core sketch draws the nebula background. Whispers and story are
+// loaded separately and attached by main.js when needed.
 
 if (typeof window.dat === 'undefined' || typeof window.dat.GUI === 'undefined') {
   throw new Error('dat.GUI not loaded');
@@ -41,7 +42,6 @@ function buildVignette() {
 // Config + State
 // =====================
 const params = {
-  mode:       'Story',
   noiseScale: 0.002,
   tSpeed:     0.007,
   octaves:    8,
@@ -57,16 +57,12 @@ let gui, editorFolder, paletteController;
 let guiHidden = false;
 
 let whispers;
-let storyEngine;
 let whispersEnabled = true;
-window.setWhispersEnabled = flag => { whispersEnabled = flag; };
 
-function handleMode() {
-  const isWhispers = params.mode === 'Whispers';
-  const el = document.getElementById('story-container');
-  if (el) el.style.display = isWhispers ? 'none' : 'flex';
-  whispersEnabled = isWhispers;
-}
+export const setWhispersOverlay = w => { whispers = w; };
+export const setWhispersEnabled = flag => { whispersEnabled = flag; };
+export const getGUI = () => gui;
+export const getPaletteName = () => params.palette;
 // Built-in palettes (HSB triples)
 const BASE_PALETTES = {
   Nebula:   [ [300,80,90], [230,80,90], [190,70,90], [160,70,90] ],
@@ -115,7 +111,6 @@ function setup() {
 
   // GUI
   gui = new dat.GUI();
-  gui.add(params, 'mode', ['Whispers','Story']).name('Mode').onChange(handleMode);
   gui.add(params, 'noiseScale', 0.0005, 0.01, 0.0001).name('Noise Scale').onChange(saveParams);
   gui.add(params, 'tSpeed',     0.001,  0.1,  0.001).name('Time Speed').onChange(saveParams);
   gui.add(params, 'octaves',    1,      16,   1).name('Octaves')
@@ -138,11 +133,6 @@ function setup() {
   vig.add(vignette, 'x', 0, 1, 0.01).name('Center X').onChange(buildVignette);
   vig.add(vignette, 'y', 0, 1, 0.01).name('Center Y').onChange(buildVignette);
   buildVignette();
-
-  // Whispers overlay module
-  whispers = createWhispers(gui, () => params.palette);
-  storyEngine = NebulaStory.quickBind({ textDefaults: TEXT_DEFAULTS });
-  handleMode();
 
   // Hide GUI by default unless ?gui=1
   const showFromQuery = new URLSearchParams(location.search).get('gui') === '1';
@@ -190,7 +180,7 @@ function draw() {
   }
 
   // whispers overlay once
-  if (whispersEnabled) {
+  if (whispersEnabled && whispers) {
     whispers.update(deltaTime);
     whispers.draw();
   }


### PR DESCRIPTION
## Summary
- Refactor `main.js` into ES module that dynamically loads `whispers.js` and `story.js`
- Strip whisper and story dependencies from `sketch.js` and expose helpers for overlays
- Update `index.html` and documentation to outline modular architecture

## Testing
- `node --check --input-type=module < nebula-art/main.js`
- `node --check --input-type=module < nebula-art/sketch.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28812496083209e864aeb7ae564c4