### PR TITLE
fix: ensure GUI overlay captures input

### DIFF
--- a/nebula-art/nebula.css
+++ b/nebula-art/nebula.css
@@ -25,6 +25,12 @@ br {
 /* Mode switch stays on top */
 #mode-switch { z-index: 1000; }
 
+/* dat.GUI controls should sit above canvas and overlays */
+.dg {
+  z-index: 2000 !important;
+  pointer-events: auto;
+}
+
 /* Layout for switch and story overlay */
 #mode-switch {
   position: fixed;

--- a/nebula-art/sketch.js
+++ b/nebula-art/sketch.js
@@ -111,6 +111,9 @@ function setup() {
 
   // GUI
   gui = new dat.GUI();
+  // Ensure GUI floats above sketch and can capture input
+  gui.domElement.style.zIndex = '2000';
+  gui.domElement.style.pointerEvents = 'auto';
   gui.add(params, 'noiseScale', 0.0005, 0.01, 0.0001).name('Noise Scale').onChange(saveParams);
   gui.add(params, 'tSpeed',     0.001,  0.1,  0.001).name('Time Speed').onChange(saveParams);
   gui.add(params, 'octaves',    1,      16,   1).name('Octaves')
@@ -312,7 +315,12 @@ function keyPressed() {
   if (key === 's' || key === 'S') saveCanvas('nebula', 'png');
   if (key === 'g' || key === 'G') {
     guiHidden = !guiHidden;
-    if (gui) gui.domElement.style.display = guiHidden ? 'none' : '';
+    if (gui) {
+      gui.domElement.style.display = guiHidden ? 'none' : '';
+      gui.domElement.style.pointerEvents = guiHidden ? 'none' : 'auto';
+      const container = document.getElementById('sketch-container');
+      if (container) container.style.pointerEvents = guiHidden ? 'auto' : 'none';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- raise dat.GUI's z-index so it renders above canvas and overlays
- disable the canvas when the GUI is visible so pointer events reach the controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28aad43048320b1477d6e16f21940