### PR TITLE
Stack end-of-story options vertically

### DIFF
--- a/nebula-art/nebula.css
+++ b/nebula-art/nebula.css
@@ -17,11 +17,6 @@ body {
   z-index: 1;
 }
 
-br {
-    display: inline;
-}
-
-
 /* Mode switch stays on top */
 #mode-switch { z-index: 1000; }
 
@@ -58,6 +53,7 @@ br {
 #story-title { margin: 0 0 8px 0; font-size: 70px; color: #ff9292; }
 #story-body  { margin: 0 0 12px 0; font-size: 30px; color: #ff9292; }
 #story-choices { display: flex; justify-content: center; flex-wrap: wrap; gap: 8px; }
+#story-choices.ending { flex-direction: column; align-items: center; }
 #story-path { margin-top: 8px; font-size: 12px; opacity: .85; }
 .sr-only { position: absolute; height: 1px; width: 1px; overflow: hidden; clip: rect(1px,1px,1px,1px); white-space: nowrap; }
 #story-wrap h2, #story-wrap p, #story-path, #story-title, #story-body {

--- a/nebula-art/story.js
+++ b/nebula-art/story.js
@@ -162,6 +162,7 @@ Hold your breath, and you will dissolve into listening until the listening speak
         if ($body) $body.textContent = node.text;
         if ($path) $path.textContent = path;
         if ($choices) {
+          $choices.classList.remove("ending");
           $choices.innerHTML = "";
           node.choices.forEach(c => {
             const btn = document.createElement("button");
@@ -187,16 +188,11 @@ Hold your breath, and you will dissolve into listening until the listening speak
         if ($path) $path.textContent = fullPath + " → " + id;
         if ($choices) {
           $choices.innerHTML = "";
+          $choices.classList.add("ending");
           const hint = document.createElement("div");
           hint.className = "whisper";
           hint.textContent = end.whisper;
           $choices.appendChild(hint);
-
-          // break line so replay button sits below hint
-          const br1 = document.createElement("br");
-          const br2 = document.createElement("br");
-          $choices.append(br1, br2); // Works in modern browsers
-
 
           const again = document.createElement("button");
           again.className = "btn again";


### PR DESCRIPTION
## Summary
- Add `ending` class to story choices on ending to stack whisper hint and restart button vertically
- Remove manual `<br>` usage and reset layout when rendering new nodes
- Style `#story-choices.ending` with column layout and centered items

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28d4397dc8320a71d5eb743881c7d