### PR TITLE
Unify button styling and update text color

### DIFF
--- a/nebula-art/nebula.css
+++ b/nebula-art/nebula.css
@@ -1,5 +1,5 @@
 :root{
-  --ink:#eaeaf2;
+  --ink:#000;
   --panel:rgba(0,0,0,0.55);
   --ring:#7dd3fc;
   --accentA1:#e879f9;  /* A = voice/motion */
@@ -94,18 +94,9 @@ body {
   .btn, .btn::before{ animation: none !important; transition: none !important; }
 }
 
-/* Choice variants */
-.choice.btn{
-  background: linear-gradient(#0000,#0000), var(--panel);
-  border:1px solid #ffffff25;
-}
-.choice.btn.btn--A{
-  --accentA1:#ff9bd6; --accentA2:#c084fc; --accentB1:#ff9bd6; --accentB2:#c084fc;
-}
-.choice.btn.btn--B{
-  --accentA1:#7dd3fc; --accentA2:#60a5fa; --accentB1:#7dd3fc; --accentB2:#60a5fa;
-}
-.choice.btn.picked{
+
+/* Selected state */
+.btn.picked{
   box-shadow: 0 0 0 3px rgba(255,255,255,.08), 0 10px 30px rgba(120,180,255,.28);
 }
 

--- a/nebula-art/story.js
+++ b/nebula-art/story.js
@@ -166,7 +166,7 @@ Hold your breath, and you will dissolve into listening until the listening speak
           $choices.innerHTML = "";
           node.choices.forEach(c => {
             const btn = document.createElement("button");
-            btn.className = `btn choice btn--${c.key}`;
+            btn.className = "btn";
             btn.textContent = c.label;
             btn.title = c.whisper;
             btn.onclick = () => {
@@ -178,7 +178,7 @@ Hold your breath, and you will dissolve into listening until the listening speak
             $choices.appendChild(btn);
           });
           // focus first choice for keyboard users
-          const first = $choices.querySelector(".choice");
+          const first = $choices.querySelector(".btn");
           if (first) first.focus();
         }
       },
@@ -195,7 +195,7 @@ Hold your breath, and you will dissolve into listening until the listening speak
           $choices.appendChild(hint);
 
           const again = document.createElement("button");
-          again.className = "btn again";
+          again.className = "btn";
           again.textContent = "Try a different cadence";
           again.onclick = () => engine.reset();
           $choices.appendChild(again);


### PR DESCRIPTION
## Summary
- Use single `.btn` class for mode, choice, and restart buttons
- Remove choice-specific CSS and highlight picked buttons with `.btn.picked`
- Switch button text color to black via `--ink`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a29169fa3c8320b556976fe1d7f534