### PR TITLE
Add basic tests for story and whisper modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "endub-22.github.io",
+  "version": "1.0.0",
+  "description": "This repository hosts the **Nebula Art** experiment. The web app is composed of several small scripts coordinated by `main.js`.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/test/story.test.js
+++ b/test/story.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+globalThis.window = globalThis;
+await import('../nebula-art/story.js');
+const { TEXT_DEFAULTS } = await import('../nebula-art/whispers.js');
+
+test('endingId maps paths to correct endings', () => {
+  const { endingId } = globalThis.NebulaStory;
+  assert.equal(endingId('ABBBB'), 'E2');
+  assert.equal(endingId('AABBB'), 'E3');
+  assert.equal(endingId('AAABB'), 'E4');
+  assert.equal(endingId('AAAAB'), 'E5');
+  assert.equal(endingId('BAAAA'), 'E6');
+  assert.equal(endingId('AAAAA'), 'E7');
+  assert.equal(endingId('ABABA'), 'E8');
+  assert.equal(endingId('AAABA'), 'E9');
+  assert.equal(endingId('BABBB'), 'E10');
+});
+
+test('endingId rejects invalid paths', () => {
+  const { endingId } = globalThis.NebulaStory;
+  assert.throws(() => endingId('ABC'), /Path must be exactly 5 choices/);
+});
+
+test('createStoryEngine computes ending from choices', () => {
+  const { createStoryEngine } = globalThis.NebulaStory;
+  let observed;
+  const engine = createStoryEngine({
+    onRenderNode: () => {},
+    onRenderEnding: (_, id) => { observed = id; }
+  });
+  engine.start();
+  'AAABA'.split('').forEach(c => engine.choose(c));
+  assert.equal(observed, 'E9');
+});
+
+test('TEXT_DEFAULTS exposes expected values', () => {
+  assert.equal(TEXT_DEFAULTS.textEnabled, true);
+  assert.equal(TEXT_DEFAULTS.textSize, 72);
+  assert.equal(TEXT_DEFAULTS.textFadeInMs, 2000);
+});


### PR DESCRIPTION
## Summary
- configure Node-based test runner
- add tests for NebulaStory and whisper defaults

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a292e70a2c8320a6c11deba6cee818