### PR TITLE
Add delay for story transitions

### DIFF
--- a/nebula-art/story.js
+++ b/nebula-art/story.js
@@ -173,7 +173,7 @@ Hold your breath, and you will dissolve into listening until the listening speak
               btn.classList.add("picked");
               setTimeout(() => btn.classList.remove("picked"), 350);
               if (typeof onChoiceSound === "function") onChoiceSound(c.key);
-              engine.choose(c.key);
+              setTimeout(() => engine.choose(c.key), 250);
             };
             $choices.appendChild(btn);
           });
@@ -197,7 +197,11 @@ Hold your breath, and you will dissolve into listening until the listening speak
           const again = document.createElement("button");
           again.className = "btn";
           again.textContent = "Try a different cadence";
-          again.onclick = () => engine.reset();
+          again.onclick = () => {
+            again.classList.add("picked");
+            setTimeout(() => again.classList.remove("picked"), 350);
+            setTimeout(() => engine.reset(), 250);
+          };
           $choices.appendChild(again);
         }
         if ($ending) $ending.textContent = id;


### PR DESCRIPTION
## Summary
- allow button ripple animation to play before choosing story options
- trigger retry button ripple and delay reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a298bc948c83208a1805c50ef6d39e